### PR TITLE
Fix mapping url with slug

### DIFF
--- a/src/pages/insurance/index.tsx
+++ b/src/pages/insurance/index.tsx
@@ -13,6 +13,7 @@ interface AllJSON {
 }
 
 interface Node {
+  url: string;
   meta: Meta;
 }
 
@@ -37,10 +38,9 @@ const IndexPage = (props: {data: Data}) => {
 
         <ul>
           {props.data.allJson.nodes.map(node => {
-            const url = node.meta.vehicleKey.substring(0, 4) + "-" + node.meta.vehicleKey.substring(4, 6) + "-" + node.meta.vehicleKey.substring(6, 8);
             return (
               <li>
-                <a href={`/insurance/${node.meta.insureLevel}/${url.toLowerCase()}/`}>{node.meta.brand} - {node.meta.model} - {node.meta.subModel} - {node.meta.year}</a>
+                <a href={node.url}>{node.meta.brand} - {node.meta.model} - {node.meta.subModel} - {node.meta.year}</a>
               </li>
             );
           })}
@@ -63,6 +63,7 @@ export const query = graphql`
   query {
     allJson(sort: {meta: {brand: ASC}}) {
       nodes {
+        url: gatsbyPath(filePath: "/insurance/{json.meta__insureLevel}/{json.meta__vehicleKey}")
         meta {
           brand
           cc
@@ -70,7 +71,6 @@ export const query = graphql`
           model
           subModel
           vehicleKey
-          url
           year
         }
       }

--- a/src/pages/insurance/{json.meta__insureLevel}/{json.meta__vehicleKey}.tsx
+++ b/src/pages/insurance/{json.meta__insureLevel}/{json.meta__vehicleKey}.tsx
@@ -16,6 +16,7 @@ interface AllJSON {
 }
 
 interface AllNode {
+  url: string;
   meta: Meta;
 }
 
@@ -70,11 +71,12 @@ const InsurancePage = (props: {data: Data}) => {
             {props.data.allJson.nodes
               .filter(n=> n.meta.vehicleKey === props.data.json.meta.vehicleKey.replaceAll("-", "") && 
                       n.meta.insureLevel !== props.data.json.meta.insureLevel )
-
-                     
-              .map( n=> {
-                const url = n.meta.vehicleKey.substring(0, 4) + "-" + n.meta.vehicleKey.substring(4, 6) + "-" + n.meta.vehicleKey.substring(6, 8);
-                return <li><Link to={`/insurance/${n.meta.insureLevel}/${url.toLocaleLowerCase()}`}>ชั้น{n.meta.insureLevel}</Link></li>;
+              .map(n => {
+                return (
+                  <li>
+                    <Link to={n.url}>ชั้น{n.meta.insureLevel}</Link>
+                  </li>
+                );
             })}
 
             <li><Link to="/insurance">ดูประกันอื่นๆ</Link></li>
@@ -146,6 +148,7 @@ export const query = graphql`
     query MyQuery($id: String) {
       allJson {
         nodes {
+          url: gatsbyPath(filePath: "/insurance/{json.meta__insureLevel}/{json.meta__vehicleKey}")
           meta {
             year
             insureLevel


### PR DESCRIPTION
The generated url for dynamic page be slugify. To link to the page, need to rebuild the path by `gatsbyPath`.

This PR change the logic of building the path manually to use `gatbyPath`.

ref: https://www.gatsbyjs.com/docs/reference/routing/file-system-route-api/#routing-and-linking